### PR TITLE
Make reference value discussion apply to both types of Appraisal Policy

### DIFF
--- a/draft-ietf-rats-architecture.md
+++ b/draft-ietf-rats-architecture.md
@@ -325,25 +325,27 @@ might be obtained from an Endorser along with the Endorsements, or might be obta
 via some other mechanism such as being configured in the Verifier by an
 administrator.
 
-For example, for some claims the Verifier might check the values of claims in the
-Evidence against constraints specified in the Appraisal Policy for Evidence.  Such constraints might
-involve a comparison for equality against reference values, or a check for being in
-a range bounded by reference values, or membership in a set of reference values,
-or a check against values in other claims, or any other test.
-
-Such reference values might be specified as part of the Appraisal Policy for Evidence itself,
-or might be obtained from a separate source, such as an Endorsement, and then used by
-the Appraisal Policy for Evidence.
-The actual data format and semantics of a known-good value are specific to
-claims and implementations.
-There is no general purpose format for them or general means for comparison defined in this architecture document.
-Similarly, for some claims the Verifier might check the values of claims in the Evidence for membership in a set, or against a range of values, or against known-bad values such as an expiration time.
-These reference values may be conveyed to the Verifier as part of an Endorsement or as part of Appraisal Policy or both as these are the two input paths to the Verifier.
-
 The Relying Party uses Attestation Results by applying its own
 Appraisal Policy to make application-specific decisions such as authorization decisions.
 The Attestation Result Appraisal Policy might, for example, be configured in the Relying Party
 by an administrator.
+
+## Appraisal Policies
+
+An appraising party (i.e., the Verifier appraising evidence, or the Relying Party
+appraising an Attestation Result) checks the values of some claims
+against constraints specified in the Appraisal Policy.  Such constraints might
+involve a comparison for equality against a reference value, or a check for being in
+a range bounded by reference values, or membership in a set of reference values,
+or a check against values in other claims, or any other test.
+
+Such reference values might be specified as part of the Appraisal Policy itself,
+or might be obtained from a separate source, such as an Endorsement, and then used by
+the Appraisal Policy.
+
+The actual data format and semantics of any reference values are specific to
+claims and implementations. This architecture document does not define any
+general purpose format for them or general means for comparison.
 
 ## Two Types of Environments of an Attester
 

--- a/draft-ietf-rats-architecture.md
+++ b/draft-ietf-rats-architecture.md
@@ -334,7 +334,7 @@ by an administrator.
 
 The Verifier, when appraising Evidence, or the Relying Party, when
 appraising Attestation Results, checks the values of some claims
-against constraints specified in the Appraisal Policy.  Such constraints might
+against constraints specified in its Appraisal Policy.  Such constraints might
 involve a comparison for equality against a reference value, or a check for being in
 a range bounded by reference values, or membership in a set of reference values,
 or a check against values in other claims, or any other test.

--- a/draft-ietf-rats-architecture.md
+++ b/draft-ietf-rats-architecture.md
@@ -332,8 +332,8 @@ by an administrator.
 
 ## Appraisal Policies
 
-An appraising party (i.e., the Verifier appraising evidence, or the Relying Party
-appraising an Attestation Result) checks the values of some claims
+The Verifier, when appraising Evidence, or the Relying Party, when
+appraising Attestation Results, checks the values of some claims
 against constraints specified in the Appraisal Policy.  Such constraints might
 involve a comparison for equality against a reference value, or a check for being in
 a range bounded by reference values, or membership in a set of reference values,


### PR DESCRIPTION
Previously the text was specific to policy for Evidence, but the same
applies to policy for appraising Attestation Results, so generalizing
the text.

This also removes a redundant sentence where older text and newly merged text from this morning said the same thing.  And the diffs look larger than they really are, since some text was just moved around to be in a different order.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>