### PR TITLE
added refactor of handle-based example to current head

### DIFF
--- a/draft-ietf-rats-architecture.md
+++ b/draft-ietf-rats-architecture.md
@@ -1156,7 +1156,7 @@ or might be defined relative to some other timestamp or timeticks counter.
 | HD | Handle distribution         | A centrally generated identifier for time-bound recentness across a domain of devices is successfully distributed to Attesters.
 | NS | Nonce sent                  | A nonce not predictable to an Attester (recentness & uniqueness) is sent to an Attester.
 | NR | Nonce relayed               | A nonce is relayed to an Attester by another entity.
-| HR | Handle received             | A handle distributed by a Handle Distributor was received
+| HR | Handle received             | A handle distributed by a Handle Distributor was received.
 | EG | Evidence generation         | An Attester creates Evidence from collected Claims.
 | ER | Evidence relayed            | A Relying Party relays Evidence to a Verifier.
 | RG | Result generation           | A Verifier appraises Evidence and generates an Attestation Result.

--- a/draft-ietf-rats-architecture.md
+++ b/draft-ietf-rats-architecture.md
@@ -1290,18 +1290,18 @@ As any other role, the Handle Distributor role can be taken on by a dedicated en
 The use of handles can compensate for a lack of clocks or other sources of time on entities taking on RATS roles.
 The only entity that requires access to a source of time is the entity taking on the role of Handle Distributor.
 
-Handles are different to nonces as they are not used only once and are used by more than one entity at the same time.
-Handles are different to timestamps as they do not have to convey information about a point in time, but their reception creates that information.
+Handles are different from nonces as they can be used more than once and can be used by more than one entity at the same time.
+Handles are different from timestamps as they do not have to convey information about a point in time, but their reception creates that information.
 The reception of a handle is similar to the event that increments a relative tickcounter.
-The event at which a handle is received a new (most recent) handle outdates (and therefore invalidates) the former received handle.
+Receipt of a new handle invalidates a previously received handle. 
 
 In this example, Evidence generation based on received handles always uses the current (most recent) handle.
 As handles are distributed over the network, all involved entities receive a fresh handle at roughly the same time.
 The time that represents this event is named Handle received: time(HR). Due to distribution over the network, there is some jitter with respect to time(HR) for each involved entity.
 To compensate for this jitter, there is a small period of overlap (a specified offset) in which both a current handle and corresponding former handle are valid in Evidence appraisal: `validity-duration = time(HR') + offset - time(HR)`. The offset is typically based on a network's round trip time.
-Analogously, the generation of valid Evidence is only possible, if the age of the handle used is lower than the validity-duration: `delta(time(EG),time(HR) < validity-duration`.
+Analogously, the generation of valid Evidence is only possible, if the age of the handle used is lower than the validity-duration: `time(HR) - time(EG) < validity-duration`.
 
-From the point of view of a Verifier, the generation of valid Evidence is only possible, if the age of the handle used in the Evidence generation is younger than the duration of the distribution interval -- "delta(time(HD),time(EG)) \< delta(time(HD),time(HD'))".
+From the point of view of a Verifier, the generation of valid Evidence is only possible, if the age of the handle used in the Evidence generation is younger than the duration of the distribution interval -- "(time(HD')-time(HD)) - (time(HR)-time(EG)) \< validity-duration".
 
 Due to the validity-duration of handles, multiple different pieces of Evidence can be generated based on the same handle.
 The resulting granularity (time resolution) of Evidence freshness is typically lower than the resolution of clock-based tickcounters.


### PR DESCRIPTION
This is an evolution of PR #123 and based on Issue #111 

Attester Awareness time(AA) is not included in this PR (see #144), but a concise definition of Handle received (HR).

The included diagram might need more work. Also a "background-check version" might be perceived as missing. Do we need one?

(oh and the compilations errors due to malformed references are also fixed in this PR. pls always make sure your commit compiles before push)