### PR TITLE
Update draft-ietf-rats-architecture.md

### DIFF
--- a/draft-ietf-rats-architecture.md
+++ b/draft-ietf-rats-architecture.md
@@ -155,7 +155,7 @@ Claim:
 
 Endorsement:
 
-: A secure statement that some entity (typically a manufacturer) vouches for the integrity of an Attester's signing capability
+: A secure statement that some entity (typically a manufacturer) vouches for the integrity of an Attesting Environment's various capabilities such as Claims collection and Evidence signing
 
 Endorser:
 

--- a/draft-ietf-rats-architecture.md
+++ b/draft-ietf-rats-architecture.md
@@ -155,7 +155,7 @@ Claim:
 
 Endorsement:
 
-: A secure statement that an Endorser vouches for the integrity of an Attesting Environment's various capabilities such as Claims collection and Evidence signing
+: A secure statement that an Endorser vouches for the integrity of an Attester's various capabilities such as Claims collection and Evidence signing
 
 Endorser:
 

--- a/draft-ietf-rats-architecture.md
+++ b/draft-ietf-rats-architecture.md
@@ -155,7 +155,7 @@ Claim:
 
 Endorsement:
 
-: A secure statement that some entity (typically a manufacturer) vouches for the integrity of an Attesting Environment's various capabilities such as Claims collection and Evidence signing
+: A secure statement that an Endorser vouches for the integrity of an Attesting Environment's various capabilities such as Claims collection and Evidence signing
 
 Endorser:
 


### PR DESCRIPTION
Suggested new text for Endorsements definition to make it slightly more broad, but constrained to the operations of an Attesting Environment (which is a subset of an Attester that also might contain Target Environments and other environments) which is focus for why a Verifier cares to get Endorsements. 