### PR TITLE
More fixes to handle example

### DIFF
--- a/draft-ietf-rats-architecture.md
+++ b/draft-ietf-rats-architecture.md
@@ -1561,6 +1561,10 @@ If the Relying Party had not yet received `H'`, then the Attestation Result woul
 
 In the illustrated scenario, the handle for relaying an Attestation Result to the Relying Party is current, while a previous handle was used to generate Verifier evaluated evidence. 
 This indicates that at least one epoch transition has occurred, and the Attestation Results may only be as fresh as the previous epoch.
+If the Relying Party remembers the previous handle H during an epoch window
+as discussed in {{epochfreshness}}, and the message is received during
+that window, the Attestation Result is accepted as fresh, and otherwise
+it is rejected as stale.
 
 ~~~~
                   .-------------.
@@ -1571,20 +1575,20 @@ This indicates that at least one epoch transition has occurred, and the Attestat
         |                |                |               |
         ~                ~                ~               ~
         |                |                |               |
-     time(HR_a)<---------+-----------time(HR_v)----->time(HR_r)
+     time(HR_a)<------H--+--H--------time(HR_v)----->time(HR_r)
         |                |                |               |
      time(EG_a)          |                |               |
-        |---Evidence{H,time(EG_a)-time(VG_a)}----->|               |
+        |---Evidence--------------------->|               |
+        |   {H,time(EG_a)-time(VG_a)}     |               |
         |                |                |               |
         |                |           time(RG_v)           |
         |<--Attestation Result------------|               |
-        |   {H,time(RX_v)-time(RG_v)}                |               |
+        |   {H,time(RX_v)-time(RG_v)}     |               |
         |                |                |               |
-     time(HR'_a)<--------+-----------time(HR'_v)---->time(HR'_r)
+     time(HR'_a)<-----H'-+--H'-------time(HR'_v)---->time(HR'_r)
         |                |                |               |
-     time(RR_a)          |                |               |
-        |---Attestation Result---------------------->time(RA_r)
-        |   {H',R{H,time(RX_v)-time(RG_v)}}          |               |
+        |---[Attestation Result--------------------->time(RA_r)
+        |   {H,time(RX_v)-time(RG_v)},H'] |               |
         |                |                |               |
         ~                ~                ~               ~
         |                |                |               |


### PR DESCRIPTION
Biggest bug in the last pull request is that the diagram had the attester sending a different Attestation Result than the one the Verifier gave it, which would invalidate the signature.

Second issue was that the lines didn't line up.

Third issue was that it was missing the tie to the "epoch window" discussion in {{epochfreshness}} to explain how the Relying Party deals with the mismatched handles that the example diagram has.

Fixes #198

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>