### PR TITLE
Remove confusing statement in epoch id security considerations

### DIFF
--- a/draft-ietf-rats-architecture.md
+++ b/draft-ietf-rats-architecture.md
@@ -1335,11 +1335,8 @@ For example, if an Attester produces Evidence that is relayed through some other
 
 ## Handle-based Attestation {#handles-sec}
 
-Handles, described in {{epochfreshness}}, can be tampered with, dropped, delayed and
+Handles, described in {{epochfreshness}}, can be tampered with, replayed, dropped, delayed, and
 reordered by an attacker.
-
-An attacker could be either external or belong to the distribution group, for
-example if one of the Attester entities have been compromised.
 
 An attacker who is able to tamper with handles can potentially lock all the
 participants in a certain epoch of choice for ever, effectively freezing time.


### PR DESCRIPTION
Fixes #311 by removing the sentence which didn't add any critical point.
Also mention replaying in the list of potential nefarious activities.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>